### PR TITLE
Update dune-project to fix build issue with recent dune versions

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 1.4)
 (using menhir 2.0)

--- a/jbuild-workspace
+++ b/jbuild-workspace
@@ -1,1 +1,0 @@
-(context default)


### PR DESCRIPTION
The menhir 2.0 language extension was introduced in dune 1.4, recent versions of dune check this and fail to build the project